### PR TITLE
Fix main navigation in Safari

### DIFF
--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -49,5 +49,6 @@ $displayFontFamily: Montserrat, -apple-system, BlinkMacSystemFont,
     will-change: transform;
     content: "";
     z-index: -1;
+    pointer-events: none;
   }
 }


### PR DESCRIPTION
Main navigation was broken because of the perf fix #11. Adding `pointer-events: none` fixes it.