### PR TITLE
Add mailchimp script on production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "main": "n/a",
   "scripts": {
     "start": "node ./antwar.bootstrap.js develop",
-    "build": "node ./antwar.bootstrap.js build",
+    "build": "NODE_ENV=production node ./antwar.bootstrap.js build",
     "bs:build": "export BS_CMT_POST_PROCESS_CMD=\"$PWD/node_modules/.bin/genflow.native --setProjectRoot $PWD\" && bsb -make-world",
     "bs:start": "export BS_CMT_POST_PROCESS_CMD=\"$PWD/node_modules/.bin/genflow.native --setProjectRoot $PWD\" && bsb -make-world -w",
     "bs:clean": "bsb -clean-world",

--- a/templates/page.ejs
+++ b/templates/page.ejs
@@ -9,6 +9,10 @@
     <% for (var file of htmlWebpackPlugin.options.context.cssFiles) { %>
       <link href="<%= file %>" rel="stylesheet">
     <% } %>
+
+    <% if (process.env.NODE_ENV === "production") { %>
+      <script id="mcjs">!function(c,h,i,m,p){m=c.createElement(h),p=c.getElementsByTagName(h)[0],m.async=1,m.src=i,p.parentNode.insertBefore(m,p)}(document,"script","https://chimpstatic.com/mcjs-connected/js/users/2ff99718c52457a4fa5219f66/f443b5043bc18f7a252da6d56.js");</script>
+    <% } %>
   </head>
   <body <%- htmlWebpackPlugin.options.context.helmet.bodyAttributes %>>
     <%- webpackConfig.html %>
@@ -19,5 +23,6 @@
       <script src="<%= script %>" type="text/javascript"></script>
     <% } %>
     <script src='https://js.tito.io/v1' async></script>
+
   </body>
 </html>


### PR DESCRIPTION
Mailchimp doesn't recognize our website anymore, because we forgot to inject the mailchimp script.
This PR fixes it and injects the script on production builds

![image](https://user-images.githubusercontent.com/1121889/46409300-5a6af600-c715-11e8-8a0a-3d324742251a.png)
