### PR TITLE
fix(performance): Remove unnecessary `fixed` rule from background

### DIFF
--- a/styles/variables.scss
+++ b/styles/variables.scss
@@ -44,7 +44,7 @@ $displayFontFamily: Montserrat, -apple-system, BlinkMacSystemFont,
     left: 0;
     width: 100%;
     height: 100%;
-    background: $secondaryColor url(#{$bgPath}) center top no-repeat fixed;
+    background: $secondaryColor url(#{$bgPath}) center top no-repeat;
     background-size: contain;
     will-change: transform;
     content: "";


### PR DESCRIPTION
It turns out that in the previous fix #11  I forgot to remove the `fixed` rule on the background property. So the fix was incomplete. This caused Chrome to repaint at every frame.

This PR removes the rule and finally fixes perf issues.

### Before

![2018-10-18 at 12 51](https://user-images.githubusercontent.com/11071/47149749-cb450d00-d2d4-11e8-9e57-007dcd410aae.gif)

### After

![2018-10-18 at 12 53](https://user-images.githubusercontent.com/11071/47149784-e879db80-d2d4-11e8-893e-2b931578b653.gif)

Closes #15 