### PR TITLE
Speakers page

### DIFF
--- a/components/Navigation.re
+++ b/components/Navigation.re
@@ -38,11 +38,11 @@ let make = (~pageType=Home, ~navigationLocation=Header, _children) => {
               {s("Workshops")}
             </Link>
           </li>
-          <li className=style##listItem>
-            <Link to_="/speakers/" className=style##link ?activeClassName>
-              {s("Speakers")}
-            </Link>
-          </li>
+          /*<li className=style##listItem>
+              <Link to_="/speakers/" className=style##link ?activeClassName>
+                {s("Speakers")}
+              </Link>
+            </li>*/
           <li className=style##listItem>
             <Link to_="/about/" className=style##link ?activeClassName>
               {s("About")}

--- a/components/Navigation.re
+++ b/components/Navigation.re
@@ -27,27 +27,33 @@ let make = (~pageType=Home, ~navigationLocation=Header, _children) => {
       navigationLocation == Header ? Some(style##ticketsButton) : None;
     <nav className=rootClassName>
       <ul className=style##navPrimary>
-        <li className=style##listItem>
-          <Link to_="/workshops/" className=style##link ?activeClassName>
-            {s("Workshops")}
-          </Link>
-        </li>
-        /*<li className=style##listItem>
+        /* <li className=style##listItem>
+             <Link to_="/schedule/" className=style##link ?activeClassName>
+               {s("Schedule")}
+             </Link>
+           </li> */
+
+          <li className=style##listItem>
+            <Link to_="/workshops/" className=style##link ?activeClassName>
+              {s("Workshops")}
+            </Link>
+          </li>
+          <li className=style##listItem>
             <Link to_="/speakers/" className=style##link ?activeClassName>
               {s("Speakers")}
             </Link>
-          </li>*/
-        <li className=style##listItem>
-          <Link to_="/about/" className=style##link ?activeClassName>
-            {s("About")}
-          </Link>
-        </li>
-        <li className=style##listItemBuy>
-          <a href="/#tickets" className=?ticketsClassName>
-            {s("Buy a ticket")}
-          </a>
-        </li>
-      </ul>
+          </li>
+          <li className=style##listItem>
+            <Link to_="/about/" className=style##link ?activeClassName>
+              {s("About")}
+            </Link>
+          </li>
+          <li className=style##listItemBuy>
+            <a href="/#tickets" className=?ticketsClassName>
+              {s("Buy a ticket")}
+            </a>
+          </li>
+        </ul>
       <ul className=style##navSecondary>
         <li className=style##listItem>
           <Link to_="/attendees/" className=style##link ?activeClassName>

--- a/components/header.module.scss
+++ b/components/header.module.scss
@@ -7,7 +7,7 @@
 }
 
 .logo {
-  composes: grid--6col from global;
+  composes: grid--4col from global;
   margin: 0;
 }
 
@@ -34,11 +34,21 @@
   }
 }
 
+.description {
+  grid-row: 2;
+  grid-column: span 6;
+  font-size: 120%;
+  margin-left: 2rem;
+}
+
 .meta {
-  composes: grid--6col from global;
-  margin-top: 2em;
+  grid-column: 9 / 13;
+  margin-top: -1rem;
+
   @media (max-width: 768px) {
-    text-align: center;
+    margin-top: 0;
+    margin-bottom: 2rem;
+    margin-left: 2rem;
   }
   p {
     margin: 0;
@@ -46,10 +56,10 @@
 }
 
 .dates {
-  margin: 0.5em 0;
+  margin: 0;
   color: $bgColor;
   font-weight: 600;
-  font-size: 150%;
+  font-size: 200%;
 }
 
 .nav {
@@ -60,6 +70,6 @@
 }
 
 .nav_home {
-  composes: push--1col from global;
-  composes: pull--1col from global;
+  grid-row: 1;
+  grid-column: 5 / 13;
 }

--- a/components/header.re
+++ b/components/header.re
@@ -24,7 +24,15 @@ let make = (~pageType, _children) => {
       <div className="container">
         {
           if (isHomePage) {
-            logoEl;
+            <>
+              logoEl
+              <p className=style##description>
+                {
+                  {j|The ReasonML conference for web developers & OCaml enthusiasts|j}
+                  |> s
+                }
+              </p>
+            </>;
           } else {
             <Link to_="/" className=style##link_home> logoEl </Link>;
           }
@@ -33,14 +41,6 @@ let make = (~pageType, _children) => {
           componentOrNull(
             isHomePage,
             <div className=style##meta>
-              <p className=style##description>
-                <strong>
-                  {
-                    {j|The ReasonML conference for web developers & OCaml enthusiasts|j}
-                    |> s
-                  }
-                </strong>
-              </p>
               <h2 className=style##dates>
                 <time dateTime="2019-04-11/2019-04-13">
                   {{j|11–13 April 2019|j} |> s}

--- a/components/navigation.module.scss
+++ b/components/navigation.module.scss
@@ -2,6 +2,8 @@
 
 .root_header {
   width: 100%;
+  display: flex;
+  flex-direction: column;
 
   .link {
     display: block;
@@ -17,6 +19,8 @@
 }
 
 .navPrimary {
+  order: 1;
+  flex: 1 0 100%;
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -32,6 +36,7 @@
 
 .navSecondary {
   composes: navPrimary;
+  order: 0;
   font-size: 75%;
 }
 

--- a/components/offeringSection.module.scss
+++ b/components/offeringSection.module.scss
@@ -38,8 +38,7 @@
   }
 
   h2 {
-    margin: 0;
-    line-height: 1;
+    margin-top: 0;
   }
 
   img {

--- a/components/organizers.module.scss
+++ b/components/organizers.module.scss
@@ -5,6 +5,7 @@
   composes: grid_12 from global;
   composes: grid--full from global;
   margin: 1em 0;
+  padding: 0 20px;
   justify-content: space-between;
   flex-wrap: wrap;
 }

--- a/components/speakerDetails.module.scss
+++ b/components/speakerDetails.module.scss
@@ -5,6 +5,11 @@
   display: flex;
   flex-direction: row;
   margin-top: 2rem;
+
+  @media (max-width: 1000px) {
+    margin-left: 30px;
+    margin-right: 30px;
+  }
 }
 
 .speakerCard {

--- a/components/speakerDetails.module.scss
+++ b/components/speakerDetails.module.scss
@@ -1,42 +1,39 @@
 @import "../styles/variables.scss";
 
 .root {
-  composes: grid from global;
-  composes: grid_12 from global;
-  margin: 2em 0;
+  grid-column: span 6;
+  display: flex;
+  flex-direction: row;
+  margin-top: 2rem;
 }
 
 .speakerCard {
-  composes: grid--2col from global;
+  flex: 0 0 65px;
+  margin-right: 10px;
 
   figcaption {
     display: none;
   }
 }
 
-.description {
-  composes: grid--10col from global;
-}
-
-.figure {
-  grid-row-start: 1;
-  grid-column-start: 1;
-  margin: 0;
-}
-
-.image {
-  display: block;
-  width: 150px;
-  border-radius: 50%;
-}
-
 .name {
-  margin: 0;
-  font-size: x-large;
+  margin-top: 0;
+  line-height: 1.3;
+  font-size: 200%;
+}
+
+.description {
+}
+
+.meta {
+  grid-column: span 3;
+}
+
+.talks {
+  grid-column: span 3;
 }
 
 .company {
-  margin: 0;
   color: $secondaryTextColor;
 }
 

--- a/components/speakerDetails.re
+++ b/components/speakerDetails.re
@@ -11,10 +11,12 @@ let component = ReasonReact.statelessComponent("SpeakerDetails");
 let make = (~speaker: Data.Speaker.t, _children) => {
   ...component,
   render: _self =>
-    <section className=style##root id={Data.Speaker.speakerAnchor(speaker)}>
+    <section className=style##root>
       <section className=style##speakerCard> <SpeakerCard speaker /> </section>
       <section className=style##description>
-        <h2 className=style##name> {speaker.name |> s} </h2>
+        <h2 className=style##name id={Data.Speaker.speakerAnchor(speaker)}>
+          {speaker.name |> s}
+        </h2>
         <p className=style##company>
           {speaker.company ++ ", " |> s}
           <div className=style##social>
@@ -24,16 +26,15 @@ let make = (~speaker: Data.Speaker.t, _children) => {
           </div>
         </p>
         {speaker.description |> md}
-        {
-          switch (speaker.talk) {
-          | Some(t) =>
-            <strong>
-              {{j|🗣|j} |> s}
+        <section className=style##meta>
+          {
+            switch (speaker.talk) {
+            | Some(t) =>
               <Link to_={"/schedule/#" ++ talkSlug(t)}> {t.title |> s} </Link>
-            </strong>
-          | None => ReasonReact.null
+            | None => ReasonReact.null
+            }
           }
-        }
+        </section>
       </section>
     </section>,
 };

--- a/pages/speakers.re
+++ b/pages/speakers.re
@@ -8,16 +8,16 @@ let toSpeakerDetail = (speaker: Data.Speaker.t) =>
 let make = _children => {
   ...component,
   render: _self =>
-    <section>
+    <div>
       <h1> {"Speakers" |> s} </h1>
-      <section>
+      <section className="container grid grid--full">
         {
           Data.Speaker.speakers
           |> Array.map(toSpeakerDetail)
           |> ReasonReact.array
         }
       </section>
-    </section>,
+    </div>,
 };
 
 let default =

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -171,6 +171,13 @@ article {
   }
 }
 
+@media (max-width: 768px) {
+  .grid--full {
+    margin-left: -20px;
+    margin-right: -20px;
+  }
+}
+
 /* Container element */
 .container {
   margin: 0 auto;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -113,6 +113,9 @@ main {
       width: 100%;
     }
   }
+  & > article {
+    padding-top: 40px;
+  }
 }
 
 article {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -32,6 +32,7 @@ h6 {
   font-weight: 600;
   font-size: 1.25rem;
   color: $primaryColor;
+  line-height: 1.2;
 }
 
 h1 {


### PR DESCRIPTION
This PR

1. Fixes and improves layout and markup of the `/speakers` page: ![2019-01-30 at 17 10](https://user-images.githubusercontent.com/11071/51994877-f03f4380-24b1-11e9-959d-9d796f4ba6b1.png)

1. Updates main navigation layout and position so it doesn't hangs in the air on the home page: 
![2019-01-30 at 17 11](https://user-images.githubusercontent.com/11071/51994955-17961080-24b2-11e9-8b8d-56d2c7405544.png)

1. Fixes "full" grid layout not taking all the space on mobile devices: ![2019-01-30 at 17 10](https://user-images.githubusercontent.com/11071/51994903-ff25f600-24b1-11e9-90ae-50f5548e9a18.png)
