### PR TITLE
Schedule tweaks

### DIFF
--- a/pages/schedule.module.scss
+++ b/pages/schedule.module.scss
@@ -48,3 +48,12 @@ $padding: 25px 15px;
   composes: headingWithAnchor from global;
   composes: talkTitleLink;
 }
+
+.speakers {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.speaker {
+}

--- a/pages/schedule.module.scss
+++ b/pages/schedule.module.scss
@@ -38,8 +38,13 @@ $padding: 25px 15px;
   color: $textColor;
 }
 
+.talkTitleLink {
+  display: inline-block;
+  margin-top: 0.2em;
+  font-size: 1em;
+}
+
 .talkTitle {
   composes: headingWithAnchor from global;
-  margin-top: 0;
-  font-size: 1em;
+  composes: talkTitleLink;
 }

--- a/pages/schedule.re
+++ b/pages/schedule.re
@@ -18,6 +18,7 @@ let toDayStr = (~date) => {
   let format = "YYYY-MM-DDTHH:mm:ss.SSSZ";
   DateFns.format(format, date);
 };
+
 let toDurationStr = (~fromTime, ~toTime) => {
   let format = "YYYY-MM-DDTHH:mm:ss.SSSZ";
   switch (toTime) {
@@ -37,18 +38,13 @@ let miscRow = (~fromTime, ~toTime, description) =>
     <dd className=style##entryDescription> {description |> s} </dd>,
   |]);
 
-/*
- A Break and a Misc type are structurally the same (for now).
- For semantic reasons, we still keep a different function
- name, in case we need to write a different render impl
- */
-let breakRow = miscRow;
-
 let talkRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
   let renderSpeaker = speaker =>
-    <Link to_={"/speakers/#" ++ Data.Speaker.speakerAnchor(speaker)}>
-      <SpeakerCard speaker compact=true />
-    </Link>;
+    <li className=style##speaker>
+      <Link to_={"/speakers/#" ++ Data.Speaker.speakerAnchor(speaker)}>
+        <SpeakerCard speaker compact=true />
+      </Link>
+    </li>;
   ReasonReact.array([|
     <dt className=style##talkTime>
       <time dateTime={toDurationStr(~fromTime, ~toTime)}>
@@ -60,20 +56,22 @@ let talkRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
         switch (List.hd(speakers).talk) {
         | Some(talk) =>
           let id = Data.Speaker.talkSlug(talk);
-          <section className=style##talkDetails id>
-            <h3 className=style##talkTitle>
+          <>
+            <h3 className=style##talkTitle id>
               {talk.title |> s}
               {" " |> s}
               <a href={"#" ++ id} title={talk.title}> {"#" |> s} </a>
             </h3>
-            {
-              speakers
-              |> List.map(renderSpeaker)
-              |> Array.of_list
-              |> ReasonReact.array
-            }
+            <ul className=style##speakers>
+              {
+                speakers
+                |> List.map(renderSpeaker)
+                |> Array.of_list
+                |> ReasonReact.array
+              }
+            </ul>
             {talk.abstract |> md}
-          </section>;
+          </>;
         | None => ReasonReact.null
         }
       }
@@ -81,11 +79,7 @@ let talkRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
   |]);
 };
 
-let workshopRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
-  let renderSpeaker = speaker =>
-    <Link to_={"/speakers/#" ++ Data.Speaker.speakerAnchor(speaker)}>
-      <SpeakerCard speaker compact=true />
-    </Link>;
+let workshopRow = (~fromTime, ~toTime) =>
   ReasonReact.array([|
     <dt className=style##talkTime>
       <time dateTime={toDurationStr(~fromTime, ~toTime)}>
@@ -93,20 +87,11 @@ let workshopRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
       </time>
     </dt>,
     <dd className=style##talkDescription>
-      <section className=style##talkDetails>
-        <Link to_="/workshops">
-          <h3 className=style##talkTitleLink> {"Workshops" |> s} </h3>
-        </Link>
-        {
-          speakers
-          |> List.map(renderSpeaker)
-          |> Array.of_list
-          |> ReasonReact.array
-        }
-      </section>
+      <Link to_="/workshops">
+        <h3 className=style##talkTitleLink> {"Workshops" |> s} </h3>
+      </Link>
     </dd>,
   |]);
-};
 
 let panelDiscussionRow = (~fromTime, ~toTime) =>
   ReasonReact.array([|
@@ -134,11 +119,11 @@ let openEndRow = (~fromTime, ~toTime, description) =>
 
 let createRow = ({task, fromTime, toTime}: Data.Timetable.entry) =>
   switch (task) {
-  | Break(description) => breakRow(~fromTime, ~toTime, description)
+  | Break(description) => miscRow(~fromTime, ~toTime, description)
   | Misc(description) => miscRow(~fromTime, ~toTime, description)
+  | OpenEnd(description) => miscRow(~fromTime, ~toTime, description)
   | Talk(speakers) => talkRow(~fromTime, ~toTime, speakers)
-  | Workshop(speakers) => workshopRow(~fromTime, ~toTime, speakers)
-  | OpenEnd(description) => openEndRow(~fromTime, description, ~toTime)
+  | Workshop(speakers) => workshopRow(~fromTime, ~toTime)
   | PanelDiscussion => panelDiscussionRow(~fromTime, ~toTime)
   };
 

--- a/pages/schedule.re
+++ b/pages/schedule.re
@@ -94,8 +94,9 @@ let workshopRow = (~fromTime, ~toTime, speakers: list(Data.Speaker.t)) => {
     </dt>,
     <dd className=style##talkDescription>
       <section className=style##talkDetails>
-        <h3 className=style##talkTitle> {"Workshop" |> s} </h3>
-        <p> {"Please see the workshop page for more details." |> s} </p>
+        <Link to_="/workshops">
+          <h3 className=style##talkTitleLink> {"Workshops" |> s} </h3>
+        </Link>
         {
           speakers
           |> List.map(renderSpeaker)

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -283,10 +283,7 @@ article {
   position: relative;
 
   & > a {
-    position: absolute;
     display: inline-block;
-    left: -1em;
-    right: 0;
     text-align: left;
     height: 100%;
     color: $secondaryTextColor;


### PR DESCRIPTION
Simplify code and HTML structure, wrap speakers for talks into `ul > li`
 
![2019-03-07 at 16 46](https://user-images.githubusercontent.com/11071/53969201-a4a73780-40f8-11e9-87f3-d4c1209fc6f8.png)
